### PR TITLE
secureHeaders and logRequest middleware

### DIFF
--- a/cmd/web/middleware.go
+++ b/cmd/web/middleware.go
@@ -1,0 +1,21 @@
+package main
+
+import "net/http"
+
+func secureHeaders(next http.Handler) http.Handler {
+	fn := func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("X-XSS-Protection", "1; mode=block")
+		w.Header().Set("X-Frame-Options", "deny")
+
+		next.ServeHTTP(w, r)
+	}
+
+	return http.HandlerFunc(fn)
+}
+
+func (app *application) logRequest(next http.Handler) http.Handler {
+	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		app.infoLog.Printf("%s - %s %s  %s", r.RemoteAddr, r.Proto, r.Method, r.URL.RequestURI())
+		next.ServeHTTP(w, r)
+	})
+}

--- a/cmd/web/routes.go
+++ b/cmd/web/routes.go
@@ -2,7 +2,7 @@ package main
 
 import "net/http"
 
-func (app *application) routes() *http.ServeMux {
+func (app *application) routes() http.Handler {
 	mux := http.NewServeMux()
 	mux.HandleFunc("/", app.home)
 	mux.HandleFunc("/post", app.showPost)
@@ -10,5 +10,6 @@ func (app *application) routes() *http.ServeMux {
 
 	fileServer := http.FileServer(http.Dir("./ui/static"))
 	mux.Handle("/static/", http.StripPrefix("/static", fileServer))
-	return mux
+
+	return app.logRequest(secureHeaders(mux))
 }


### PR DESCRIPTION
create secureHeader middleware to include some security stuff;
logRequest middleware gives log history in console everytime client side performs request